### PR TITLE
Added "fixed style sheet data" and "include style sheet in page header"

### DIFF
--- a/SmartAPI/erminas.SmartAPI/CMS/Project/ContentClasses/Elements/ITextHtml.cs
+++ b/SmartAPI/erminas.SmartAPI/CMS/Project/ContentClasses/Elements/ITextHtml.cs
@@ -59,6 +59,10 @@ namespace erminas.SmartAPI.CMS.Project.ContentClasses.Elements
     public interface ITextHtml : IText
     {
         EditorSettings TextEditorSettings { get; set; }
+
+        string FixedStyleSheet { get; set; }
+
+        bool IncludeStyleSheetInPageHeader { get; set; }
     }
 
     internal class TextHtml : Text, ITextHtml
@@ -72,6 +76,20 @@ namespace erminas.SmartAPI.CMS.Project.ContentClasses.Elements
         public EditorSettings TextEditorSettings
         {
             get { return GetAttributeValue<EditorSettings>(); }
+            set { SetAttributeValue(value); }
+        }
+
+        [RedDot("eltstylesheetdata")]
+        public string FixedStyleSheet
+        {
+            get { return GetAttributeValue<string>(); }
+            set { SetAttributeValue(value); }
+        }
+
+        [RedDot("eltinsertstylesheetinpage")]
+        public bool IncludeStyleSheetInPageHeader
+        {
+            get { return GetAttributeValue<bool>(); }
             set { SetAttributeValue(value); }
         }
     }

--- a/SmartAPI/erminas.SmartAPI/CMS/Project/Pages/Elements/IStandardFieldTime.cs
+++ b/SmartAPI/erminas.SmartAPI/CMS/Project/Pages/Elements/IStandardFieldTime.cs
@@ -64,9 +64,23 @@ namespace erminas.SmartAPI.CMS.Project.Pages.Elements
             }
         }
 
+        /// <summary>
+        /// Creates the value of the standard field time from the xml node value which can be in the format
+        /// hh:mm:ss or OADate (double value)
+        /// </summary>
+        /// <param name="value">Value from the xml node</param>
+        /// <returns>Time parsed from the xml node</returns>
         protected override TimeSpan FromXmlNodeValue(string value)
         {
-            return value.ToOADate().TimeOfDay;
+            // There are two different format, either hh:mm:ss or as OADate (double value)
+            if (value.Contains(":"))
+            {
+                return TimeSpan.Parse(value.Replace(",", "."), CultureInfo.InvariantCulture);
+            }
+            else
+            {
+                return value.ToOADate().TimeOfDay;
+            }
         }
 
         protected override string GetXmlNodeValue()

--- a/SmartAPI/erminas.SmartAPI/CMS/RedDotAttributeDescriptionUtils.cs
+++ b/SmartAPI/erminas.SmartAPI/CMS/RedDotAttributeDescriptionUtils.cs
@@ -157,7 +157,9 @@ namespace erminas.SmartAPI.CMS
                 {"ignoreglobalworkflow", "Not relevant for global content workflow"},
                 {"keywordrequired", "Keyword required"},
                 {"requiredcategory", "Keyword required from category"},
-                {"selectinnewpage", "Available via the shortcut menu in SmartEdit"}
+                {"selectinnewpage", "Available via the shortcut menu in SmartEdit"},
+                {"eltstylesheetdata", "Assign fixed style sheet"},
+                {"eltinsertstylesheetinpage", "Include style sheet in page header"}
             };
 
         public static string GetDescriptionForElement(string name)


### PR DESCRIPTION
for HTML Text elements. Both are available via the Action Menu. Just manual tests done so far.

Those elements haven't been integrated before. They are available also for old CMS versions back to 7.5 as far as I know. I only have done manual tests which worked successfully. Those attributes are not always set in the XML as far as I see. If the fixed style sheet has not been set it is null via the SmartAPI.
