### PR TITLE
Fix project unavailable at login

### DIFF
--- a/SmartAPI/erminas.SmartAPI/CMS/ISession.cs
+++ b/SmartAPI/erminas.SmartAPI/CMS/ISession.cs
@@ -837,36 +837,29 @@ namespace erminas.SmartAPI.CMS
 
         private static bool IsProjectUnavailbaleException(Exception e)
         {
-            return
-                e.Message.Contains(
-                    "The project you have selected is no longer available. Please select a different project via the Main Menu.");
+            return e.Message.Contains("The project you have selected is no longer available. Please select a different project via the Main Menu.");
         }
 
-        private void LoadSelectedProject(XmlDocument xmlDoc)
+        private void LoadSelectedProject(XmlNode xmlDoc)
         {
             var lastModule = (XmlElement) xmlDoc.SelectSingleNode("/IODATA/USER/LASTMODULES/MODULE[@last='1']");
-            if (lastModule == null)
-            {
-                return;
-            }
+            var projectStr = lastModule?.GetAttributeValue("project");
 
-            string projectStr = lastModule.GetAttributeValue("project");
-            if (!string.IsNullOrEmpty(projectStr))
+            if (string.IsNullOrEmpty(projectStr)) return;
+
+            try
             {
-                try
+                SelectProject(Guid.Parse(projectStr));
+            }
+            catch (SmartAPIException e)
+            {
+                if (IsProjectUnavailbaleException(e) || e.InnerException != null && IsProjectUnavailbaleException(e.InnerException))
                 {
-                    SelectProject(Guid.Parse(projectStr));
-                } catch (SmartAPIException e)
+                    SelectedProjectGuid = Guid.Empty;
+                }
+                else
                 {
-                    if (IsProjectUnavailbaleException(e) ||
-                        (e.InnerException != null && IsProjectUnavailbaleException(e.InnerException)))
-                    {
-                        SelectedProjectGuid = Guid.Empty;
-                    }
-                    else
-                    {
-                        throw;
-                    }
+                    throw;
                 }
             }
         }

--- a/SmartAPI/erminas.SmartAPI/CMS/ISession.cs
+++ b/SmartAPI/erminas.SmartAPI/CMS/ISession.cs
@@ -837,7 +837,9 @@ namespace erminas.SmartAPI.CMS
 
         private static bool IsProjectUnavailbaleException(Exception e)
         {
-            return e.Message.Contains("The project you have selected is no longer available. Please select a different project via the Main Menu.");
+            return e.Message.Contains("The project you have selected is no longer available. Please select a different project via the Main Menu.") ||
+                   e.Message.Contains("Access to this project has been denied, because you are not assigned to it.") || 
+                   e.Message.Contains("Ihnen wird der Zugang zu diesem Projekt verweigert, da Sie ihm nicht zugewiesen sind.");
         }
 
         private void LoadSelectedProject(XmlNode xmlDoc)


### PR DESCRIPTION
## Problembeschreibung
Ein Benutzer ist zuletzt im Projekt A eingeloggt gewesen. Wird ihm die Berechtigung zu Projekt A entzogen und er loggt sich erneut im CMS ein, wird ihm eine entsprechende Fehlermeldung angezeigt und er kann das Projekt wechseln. Bei Verwendung der SmartAPI wird aktuell eine Exception ("Couldn't select project...") geworfen. Ein wechseln des Projectes oder die Verwendung projektunabhängiger Funktionen ist dadurch nicht möglich.

## Problemlösung
Beim Login wird die Funktion `LoadSelectedProject` aufgerufen, welche das letzte ausgewählte Projekt lädt. In dieser Funktion wird wird bereits mittels `IsProjectUnavailbaleException` überprüft ob das Projekt verfügbar ist. Dabei wird ein einfacher Stringvergleich der Fehlermeldung vorgenommen. Dieser wurde um die aktuelle Fehlermeldung (Englisch / Deutsch) ergänzt.

Überprüft mit OpenText Management Server 11.2.2.*