### PR TITLE
Update workflow RQL query with option="complete"

### DIFF
--- a/SmartAPI/erminas.SmartAPI/CMS/Project/Workflows/IWorkflow.cs
+++ b/SmartAPI/erminas.SmartAPI/CMS/Project/Workflows/IWorkflow.cs
@@ -83,7 +83,7 @@ namespace erminas.SmartAPI.CMS.Project.Workflows
 
         protected override XmlElement RetrieveWholeObject()
         {
-            const string LOAD_WORKFLOW = @"<WORKFLOW action=""load"" guid=""{0}""/>";
+            const string LOAD_WORKFLOW = @"<WORKFLOW action=""load"" guid=""{0}"" option=""complete""/>";
 
             return
                 (XmlElement)


### PR DESCRIPTION
From the RQL documentation, this is the query for loading the actions of a workflow. This update should allow the WorkflowActions.GetWorkflowActions method to return the list of actions (it currently always returns an empty list.)